### PR TITLE
Convert simple-job to GitHub Actions

### DIFF
--- a/.github/workflows/simple-job.yml
+++ b/.github/workflows/simple-job.yml
@@ -1,0 +1,18 @@
+name: simple-job
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on:
+      - ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v4.0.0
+      with:
+        distribution: zulu
+        java-version: '1.11'
+        settings-path: "${{ github.workspace }}"
+    - name: Run maven
+      run: mvn clean package -DskipTests=true


### PR DESCRIPTION
Pipeline migrated from [Jenkins](http://54.66.144.223:8080/job/simple-job/) :tada:

## Manual steps

Perform the following steps to complete the migration:

### simple-job
- [ ] Ensure: Java version in actions/setup-java is correct since we couldn't determine the version in use.